### PR TITLE
Fixes/return array when parsing response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    oca-epak (1.1.0)
+    oca-epak (1.2.0)
       savon (~> 2.11)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -30,14 +30,6 @@ oca.check_credentials
 => true
 ```
 
-Once you have an operation code from Oca, you can check if it's already active
-and available for use by running `#check_operativa`:
-
-```ruby
-oca.check_operativa("30-99999999-7", "77790")
-=> true
-```
-
 NOTE: Keep in mind that you cannot register/create an operation code via Oca's
 API, you have to get in touch with someone from Oca and they take care of the
 registration.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ After you have your operation code active for a given delivery type, you can
 begin calculating shipping rates and delivery estimates:
 
 ```ruby
-opts = { wt: "50", vol: "0.027", origin: "1646", destination: "2000", qty: "1",
-  cuit: "30-99999999-7", op: "77790" }
+opts = { total_weight: "50", total_volume: "0.027", origin_zip_code: "1646",
+         destination_zip_code: "2000", declared_value: "100",
+         package_quantity: "1", cuit: "30-99999999-7", operation_code: "77790" }
 
 oca.get_shipping_rates(opts)
 => [{:tarifador=>"15",

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ After you have your operation code active for a given delivery type, you can
 begin calculating shipping rates and delivery estimates:
 
 ```ruby
-opts = { wt: "50", vol: "0.027", origin: "1646", destination: "2000", qty: "1", 
+opts = { wt: "50", vol: "0.027", origin: "1646", destination: "2000", qty: "1",
   cuit: "30-99999999-7", op: "77790" }
 
 oca.get_shipping_rates(opts)
-=> {:tarifador=>"15",
+=> [{:tarifador=>"15",
     :precio=>"328.9000",
     :id_tiposervicio=>"2",
     :ambito=>"Regional",
@@ -59,7 +59,7 @@ oca.get_shipping_rates(opts)
     :total=>"328.9000",
     :xml=>"<row Tarifador=\"15\" Precio=\"328.9000\"/>",
     :"@diffgr:id"=>"Table1",
-    :"@msdata:row_order"=>"0"}
+    :"@msdata:row_order"=>"0"}]
 ```
 
 ## Contributing & Development

--- a/lib/oca-epak/base_client.rb
+++ b/lib/oca-epak/base_client.rb
@@ -20,10 +20,12 @@ module Oca
         end
       end
 
+      # @return [Array, nil]
       def parse_results_table(response, method)
         if result = parse_result(response, method)
           if result[:diffgram][:new_data_set]
-            result[:diffgram][:new_data_set][:table]
+            table = result[:diffgram][:new_data_set][:table]
+            table.is_a?(Hash) ? [table] : table
           else
             raise Oca::Errors::BadRequest.new("Oca WS responded with:\n#{response.body}")
           end

--- a/lib/oca-epak/epak/client.rb
+++ b/lib/oca-epak/epak/client.rb
@@ -17,22 +17,6 @@ module Oca
         parse_results_table(response, method).first[:existe] == "1"
       end
 
-      # Checks whether the operation is valid
-      #
-      # @param [String] Client's CUIT
-      # @param [String] Operation Type
-      # @return [Boolean]
-      def check_operation(cuit, op)
-        begin
-          opts = { wt: "50", vol: "0.027", origin: "1414", destination: "5403",
-                   qty: "1", total: "123", cuit: cuit, op: op }
-          get_shipping_rates(opts)
-          true
-        rescue Oca::Errors::GenericError => e
-          false
-        end
-      end
-
       # Creates a Pickup Order, which lets OCA know you want to make a delivery.
       #
       # @see [http://www.ombushop.com/oca/documentation.pdf] #TODO put it there

--- a/lib/oca-epak/epak/client.rb
+++ b/lib/oca-epak/epak/client.rb
@@ -14,7 +14,7 @@ module Oca
         method = :get_epack_user
         opts = { "usr" => username, "psw" => password }
         response = client.call(method, message: opts)
-        parse_results_table(response, method)[:existe] == "1"
+        parse_results_table(response, method).first[:existe] == "1"
       end
 
       # Checks whether the operation is valid
@@ -61,23 +61,26 @@ module Oca
       # Get rates and delivery estimate for a shipment
       #
       # @param [Hash] opts
-      # @option [String] :wt Total Weight e.g: 20
-      # @option [String] :vol Total Volume e.g: 0.0015 (0.1mts * 0.15mts * 0.1mts)
-      # @option [Integer] :origin Origin ZIP Code
-      # @option [Integer] :destination Destination ZIP Code
-      # @option [Integer] :qty Quantity of Packages
-      # @option [Integer] :total Declared Value
+      # @option [String] :total_weight Total Weight e.g: 20
+      # @option [String] :total_volume Total Volume e.g: 0.0015
+      #                                (0.1mts * 0.15mts * 0.1mts)
+      # @option [String] :origin_zip_code Origin ZIP Code
+      # @option [String] :destination_zip_code Destination ZIP Code
+      # @option [String] :declared_value Declared Value
+      # @option [String] :package_quantity Quantity of Packages
       # @option [String] :cuit Client's CUIT e.g: 30-99999999-7
-      # @option [String] :op Operation Type
-      # @return [Hash, nil] Contains Total Price, Delivery Estimate
+      # @option [String] :operation_code Operation Type
+      # @return [Array, nil] Contains Total Price, Delivery Estimate
       def get_shipping_rates(opts = {})
         method = :tarifar_envio_corporativo
-        message = { "PesoTotal" => opts[:wt], "VolumenTotal" => opts[:vol],
-                    "CodigoPostalOrigen" => opts[:origin],
-                    "CodigoPostalDestino" => opts[:destination],
-                    "ValorDeclarado" => opts[:total],
-                    "CantidadPaquetes" => opts[:qty], "Cuit" => opts[:cuit],
-                    "Operativa" => opts[:op] }
+        message = { "PesoTotal" => opts[:total_weight],
+                    "VolumenTotal" => opts[:total_volume],
+                    "CodigoPostalOrigen" => opts[:origin_zip_code],
+                    "CodigoPostalDestino" => opts[:destination_zip_code],
+                    "ValorDeclarado" => opts[:declared_value],
+                    "CantidadPaquetes" => opts[:package_quantity],
+                    "Cuit" => opts[:cuit],
+                    "Operativa" => opts[:operation_code] }
         response = client.call(method, message: message)
         parse_results_table(response, method)
       end

--- a/lib/oca-epak/version.rb
+++ b/lib/oca-epak/version.rb
@@ -1,5 +1,5 @@
 module Oca
   module Epak
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end

--- a/oca-epak.gemspec
+++ b/oca-epak.gemspec
@@ -3,7 +3,7 @@ require File.expand_path("../lib/oca-epak/version", __FILE__)
 Gem::Specification.new do |s|
   s.name        = 'oca-epak'
   s.version     = Oca::Epak::VERSION
-  s.date        = '2015-11-19'
+  s.date        = '2016-01-04'
   s.summary     = "OCA E-Pak"
   s.description = "Ruby wrapper for the OCA E-Pak API"
   s.authors     = ["Mauro Otonelli", "Ernesto Tagwerker"]

--- a/spec/oca-epak/epak/client_spec.rb
+++ b/spec/oca-epak/epak/client_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe Oca::Epak::Client do
   describe "#get_operation_codes" do
     context "valid user + password" do
       let(:expected_result) do
-        { :id_operativa=>"259563",
+        [{ :id_operativa=>"259563",
           :descripcion=>"259563 - ENVIOS DE SUCURSAL A SUCURSAL",
           :con_volumen=>false,
           :con_valor_declarado=>false,
           :a_sucursal=>false,
           :"@diffgr:id"=>"Table1",
-          :"@msdata:row_order"=>"0" }
+          :"@msdata:row_order"=>"0" }]
       end
 
       it "returns all the operations available for the user" do
@@ -85,9 +85,9 @@ RSpec.describe Oca::Epak::Client do
       VCR.use_cassette("get_shipping_rates") do
         response = subject.get_shipping_rates(opts)
         expect(response).to be
-        expect(response[:precio]).to eql("396.6900")
-        expect(response[:ambito]).to eql("Nacional 1")
-        expect(response[:plazo_entrega]).to eql("9")
+        expect(response.first[:precio]).to eql("396.6900")
+        expect(response.first[:ambito]).to eql("Nacional 1")
+        expect(response.first[:plazo_entrega]).to eql("9")
       end
     end
   end

--- a/spec/oca-epak/epak/client_spec.rb
+++ b/spec/oca-epak/epak/client_spec.rb
@@ -22,22 +22,6 @@ RSpec.describe Oca::Epak::Client do
     end
   end
 
-  describe "#check_operation" do
-    let(:operation_type) { "77790" }
-
-    it "returns true if the operation type exists" do
-      VCR.use_cassette("get_shipping_rates") do
-        expect(subject.check_operation(cuit, operation_type)).to be_truthy
-      end
-    end
-
-    it "returns false if the operation type doesn't exist" do
-      VCR.use_cassette("get_shipping_rates_invalid") do
-        expect(subject.check_operation(cuit, operation_type)).to be_falsey
-      end
-    end
-  end
-
   describe "#get_operation_codes" do
     context "valid user + password" do
       let(:expected_result) do

--- a/spec/oca-epak/epak/client_spec.rb
+++ b/spec/oca-epak/epak/client_spec.rb
@@ -59,12 +59,14 @@ RSpec.describe Oca::Epak::Client do
     let(:origin_zip_code) { "1646" }
     let(:destination_zip_code) { "2000" }
     let(:package_quantity) { "1" }
-    let(:operation_type) { "77790" }
+    let(:operation_code) { "77790" }
+    let(:declared_value) { "100" }
 
     it "returns the shipping price and estimated days until delivery" do
-      opts = { wt: weight, vol: volume, origin: origin_zip_code,
-        destination: destination_zip_code, qty: package_quantity, cuit: cuit,
-        op: operation_type }
+      opts = { total_weight: weight, total_volume: volume, origin_zip_code: origin_zip_code,
+        destination_zip_code: destination_zip_code,
+        declared_value: declared_value, package_quantity: package_quantity,
+        cuit: cuit, operation_code: operation_code }
 
       VCR.use_cassette("get_shipping_rates") do
         response = subject.get_shipping_rates(opts)


### PR DESCRIPTION
Hey @etagwerker, @schmierkov, 

This PR changes `parse_results_table` in the `BaseClient` class to always return an array. 

I also changed the hash keys `Epak::Client#get_shipping_rates` receives and deprecated (removed entirely) `check_operation` as it's no longer useful since the introduction of `get_operation_codes`. 

Please check it out, thanks! 