### PR TITLE
Bumped nokogiri version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,9 +24,9 @@ GEM
     httpi (2.4.1)
       rack
     method_source (0.8.2)
-    mini_portile (0.6.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    mini_portile2 (2.0.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     nori (2.6.0)
     pry (0.10.1)
       coderay (~> 1.1.0)


### PR DESCRIPTION
Hey @etagwerker, @schmierkov, 

This PR bumps the Nokogiri version, as the current one in the Gemfile.lock is vulnerable and CodeClimate is complaining about it. 

Please check it out, thanks! 