### PR TITLE
Allow custom logger on logger options

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,30 @@ response[:diffgram]
 Logging of API calls via the Savon client is disabled by default. To enable it,
 you need to set the logger options:
 
-```
+```ruby
 Oca::Logger.options = { log: true }
 ```
 
-You can also provide a log level by using `{ log: true, log_level: :fatal }`.
-The default log level is `:info`.
+The default options are:
+
+```ruby
+{
+  log: false,
+  pretty_print_xml: false,
+  log_level: :info
+}
+```
+
+You can set a different logger too:
+
+```ruby
+Oca::Logger.options = {
+  log: true,
+  pretty_print_xml: true,
+  log_level: :debug,
+  logger: Rails.logger
+}
+```
 
 ## Contributing & Development
 

--- a/lib/oca-epak/logger.rb
+++ b/lib/oca-epak/logger.rb
@@ -1,25 +1,22 @@
 module Oca
   class Logger
-    attr_accessor :log, :pretty_print_xml, :log_level
+    attr_reader :logger_options
 
-    # Receives a hash with keys `log`, `pretty_print_xml` and `log_level`.
+    # Receives a hash with keys `log`, `pretty_print_xml`, `log_level` and
+    # `logger`.
     # `log_level` can be :info, :debug, :warn, :error or :fatal
     #
     # @param opts [Hash]
     # @option opts [Boolean] :log
     # @option opts [Boolean] :pretty_print_xml
     # @option opts [Symbol] :log_level
+    # @option opts [Logger] :logger
     def initialize(opts = {})
-      @log = opts[:log] || false
-      @pretty_print_xml = opts[:pretty_print_xml] || false
-      @log_level = opts[:log_level] || :info
-    end
-
-    # Returns a hash with the logging options for Savon.
-    #
-    # @return [Hash]
-    def logger_options
-      { log: log, pretty_print_xml: pretty_print_xml, log_level: log_level }
+      @logger_options = {}
+      @logger_options[:log] = opts[:log] || false
+      @logger_options[:pretty_print_xml] = opts[:pretty_print_xml] || false
+      @logger_options[:log_level] = opts[:log_level] || :info
+      @logger_options[:logger] = opts[:logger] if opts[:logger]
     end
 
     def self.options=(opts = {})

--- a/spec/oca-epak/logger_spec.rb
+++ b/spec/oca-epak/logger_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe Oca::Logger do
   let(:default_options) do
     { log: false, pretty_print_xml: false, log_level: :info }
   end
-  let(:custom_options) { { log: true, log_level: :debug } }
+  let(:custom_options) { { log: true, log_level: :debug, logger: custom_logger } }
+  let(:custom_logger) { double(:logger) }
 
   after { Oca::Logger.options = default_options }
 


### PR DESCRIPTION
To allow log to STDOUT, Rails.logger and so on.

Was done some refactoring too by removing unnecessary variables and
methods.